### PR TITLE
support ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ TinyFS is a little filesystem with no big plans.
 
 ## Running
 
-1. To start **tinyFS** run make run in this project's root dir
+1. To start **tinyFS** run `cargo run` in this project's root dir
 2. To interact with tinyFS, open another terminal and perform file operations on `/tmp/tiny` ie `stat /tmp/tiny`
 
 ## Resources
@@ -24,7 +24,7 @@ TinyFS is a little filesystem with no big plans.
 - [format disk](./design/mkfs.md)
 - [initialize filesystem](./design/fs_init.md)
 - [stat](./design/stat.md)
-- [list directory contents]() Not Implemented
+- [ls](./design/ls.md)
 - [mkdir]() Not Implemented
 - [rmdir]() Not Implemented
 - [create]() Not Implemented

--- a/src/tiny/constants.rs
+++ b/src/tiny/constants.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use std::fs::File;
 
 pub const BLOCK_SIZE: usize = 4096;
@@ -5,8 +6,12 @@ pub const INODE_BLOCK_COUNT: u64 = 5u64;
 pub const INODE_BLOCK_BASE: u64 = 3u64 * BLOCK_SIZE as u64;
 pub const DATA_BLOCK_BASE: u64 = INODE_BLOCK_BASE + (INODE_BLOCK_COUNT * BLOCK_SIZE as u64);
 
-pub const FILE: u8 = 0;
-pub const DIR: u8 = 1;
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, PartialEq, Default)]
+pub enum InodeKind {
+    #[default]
+    File,
+    Dir,
+}
 
 pub type Disk = File;
 pub type Block = [u8; BLOCK_SIZE];

--- a/src/tiny/constants.rs
+++ b/src/tiny/constants.rs
@@ -9,3 +9,4 @@ pub const FILE: u8 = 0;
 pub const DIR: u8 = 1;
 
 pub type Disk = File;
+pub type Block = [u8; BLOCK_SIZE];

--- a/src/tiny/directory.rs
+++ b/src/tiny/directory.rs
@@ -10,7 +10,7 @@ impl DirData {
         bincode::serialize_into(buf, self)
     }
 
-    pub fn deserialize_from<R: Read>(&mut self, buf: R) -> Result<DirData, bincode::Error> {
+    pub fn deserialize_from<R: Read>(buf: R) -> Result<DirData, bincode::Error> {
         let directory: Self = bincode::deserialize_from(buf)?;
         Ok(directory)
     }
@@ -22,12 +22,12 @@ impl DirData {
 
 #[derive(Serialize, Deserialize, Default)]
 pub struct DirData {
-    entries: HashMap<String, DirEntry>,
+    pub entries: HashMap<String, DirEntry>,
 }
 
 #[derive(Serialize, Deserialize, Default)]
 pub struct DirEntry {
-    ino: u64,
-    name: String,
-    mode: u8,
+    pub ino: u64,
+    pub name: String,
+    pub kind: u8,
 }

--- a/src/tiny/directory.rs
+++ b/src/tiny/directory.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
+
 impl DirData {
     pub fn serialize_into<W: Write>(&mut self, buf: W) -> Result<(), bincode::Error> {
         bincode::serialize_into(buf, self)

--- a/src/tiny/directory.rs
+++ b/src/tiny/directory.rs
@@ -5,6 +5,8 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
+use super::constants::InodeKind;
+
 impl DirData {
     pub fn serialize_into<W: Write>(&mut self, buf: W) -> Result<(), bincode::Error> {
         bincode::serialize_into(buf, self)
@@ -29,5 +31,5 @@ pub struct DirData {
 pub struct DirEntry {
     pub ino: u64,
     pub name: String,
-    pub kind: u8,
+    pub kind: InodeKind,
 }

--- a/src/tiny/directory.rs
+++ b/src/tiny/directory.rs
@@ -4,12 +4,6 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
-
-#[derive(Serialize, Deserialize, Default)]
-pub struct DirData {
-    entries: HashMap<String, i32>,
-}
-
 impl DirData {
     pub fn serialize_into<W: Write>(&mut self, buf: W) -> Result<(), bincode::Error> {
         bincode::serialize_into(buf, self)
@@ -20,7 +14,19 @@ impl DirData {
         Ok(directory)
     }
 
-    pub fn insert(&mut self, path: &str, inode_num: i32) {
-        self.entries.insert(String::from(path), inode_num);
+    pub fn insert(&mut self, path: &str, entry: DirEntry) {
+        self.entries.insert(String::from(path), entry);
     }
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct DirData {
+    entries: HashMap<String, DirEntry>,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct DirEntry {
+    ino: u64,
+    name: String,
+    mode: u8,
 }

--- a/src/tiny/fs.rs
+++ b/src/tiny/fs.rs
@@ -1,4 +1,4 @@
-use fuse::Filesystem;
+use fuse::{FileType, Filesystem};
 use std::{
     ffi::c_int,
     io::{BufWriter, Write},
@@ -6,7 +6,7 @@ use std::{
 
 use super::{
     bitmap::Bitmap,
-    constants::{Disk, DIR},
+    constants::{Disk, DIR, FILE},
     directory::DirData,
     inode::Inode,
 };
@@ -57,7 +57,18 @@ impl Filesystem for TinyFS {
         reply.attr(&self.ttl(), &inode.to_file_attr());
     }
 
-    fn readdir(&mut self, _req: &fuse::Request, _ino: u64, _fh: u64, _offset: i64, reply: fuse::ReplyDirectory) {}
+    // TODO: if inode is a file respond with the inode
+    fn readdir(&mut self, _req: &fuse::Request, ino: u64, _fh: u64, offset: i64, mut reply: fuse::ReplyDirectory) {
+        let mut inode = Inode::load_from(&self.disk, ino).expect("error loading inode");
+        if inode.kind == FILE {
+            reply.add(inode.id, offset, FileType::RegularFile, "this file");
+        }
+
+        // load data from blocks
+        // deserialize block data into dirdata
+        // iterate through dirdata entries and add entry to reply
+        reply.ok();
+    }
 }
 
 pub struct TinyFS {

--- a/src/tiny/fs.rs
+++ b/src/tiny/fs.rs
@@ -6,7 +6,7 @@ use std::{
 
 use super::{
     bitmap::Bitmap,
-    constants::{Disk, DIR},
+    constants::{Disk, InodeKind},
     directory::DirData,
     inode::Inode,
 };
@@ -34,7 +34,7 @@ impl Filesystem for TinyFS {
         inode.block_pointers = block_ptrs;
         inode.block_count = block_count as u64;
         inode.id = root_inode as u64;
-        inode.kind = DIR;
+        inode.kind = InodeKind::Dir;
         inode
             .save_at(root_inode as u64, &self.disk)
             .expect("error saving root directory inode");
@@ -64,7 +64,7 @@ impl Filesystem for TinyFS {
 
         for (i, (name, entry)) in dir_data.entries.iter().enumerate().skip(offset as usize) {
             let mut kind = FileType::RegularFile;
-            if entry.kind == 1 {
+            if entry.kind == InodeKind::Dir {
                 kind = FileType::Directory;
             }
 

--- a/src/tiny/fs.rs
+++ b/src/tiny/fs.rs
@@ -56,6 +56,8 @@ impl Filesystem for TinyFS {
         let mut inode = Inode::load_from(&self.disk, ino).expect("error loading inode");
         reply.attr(&self.ttl(), &inode.to_file_attr());
     }
+
+    fn readdir(&mut self, _req: &fuse::Request, _ino: u64, _fh: u64, _offset: i64, reply: fuse::ReplyDirectory) {}
 }
 
 pub struct TinyFS {

--- a/src/tiny/fs.rs
+++ b/src/tiny/fs.rs
@@ -7,7 +7,7 @@ use std::{
 use super::{
     bitmap::Bitmap,
     constants::{Disk, InodeKind},
-    directory::{DirData, DirEntry},
+    directory::DirData,
     inode::Inode,
 };
 
@@ -62,7 +62,9 @@ impl Filesystem for TinyFS {
         let inode = Inode::load_from(&self.disk, ino).expect("error loading inode");
         let dir_data = self.get_dir_data(inode);
 
-        for (i, (name, entry)) in dir_data.entries.iter().enumerate().skip(offset as usize) {
+        for (i, val) in dir_data.entries.iter().enumerate().skip(offset as usize) {
+            let (name, entry) = val;
+
             let mut kind = FileType::RegularFile;
             if entry.kind == InodeKind::Dir {
                 kind = FileType::Directory;

--- a/src/tiny/fs.rs
+++ b/src/tiny/fs.rs
@@ -6,7 +6,7 @@ use std::{
 
 use super::{
     bitmap::Bitmap,
-    constants::{Disk, DIR, FILE},
+    constants::{Disk, DIR},
     directory::DirData,
     inode::Inode,
 };
@@ -28,6 +28,7 @@ impl Filesystem for TinyFS {
         let _ = inode_data.serialize_into(&mut write_buf);
         let _ = write_buf.flush();
         let data_buf = write_buf.into_inner().expect("error getting inner buffer");
+        inode.size = data_buf.len();
 
         let (block_ptrs, block_count) = self.save_data_blocks(&mut bm, data_buf);
         inode.block_pointers = block_ptrs;
@@ -57,16 +58,19 @@ impl Filesystem for TinyFS {
         reply.attr(&self.ttl(), &inode.to_file_attr());
     }
 
-    // TODO: if inode is a file respond with the inode
     fn readdir(&mut self, _req: &fuse::Request, ino: u64, _fh: u64, offset: i64, mut reply: fuse::ReplyDirectory) {
-        let mut inode = Inode::load_from(&self.disk, ino).expect("error loading inode");
-        if inode.kind == FILE {
-            reply.add(inode.id, offset, FileType::RegularFile, "this file");
+        let inode = Inode::load_from(&self.disk, ino).expect("error loading inode");
+        let dir_data = self.get_dir_data(inode);
+
+        for (i, (name, entry)) in dir_data.entries.iter().enumerate().skip(offset as usize) {
+            let mut kind = FileType::RegularFile;
+            if entry.kind == 1 {
+                kind = FileType::Directory;
+            }
+
+            reply.add(entry.ino, i as i64 + 1, kind, name);
         }
 
-        // load data from blocks
-        // deserialize block data into dirdata
-        // iterate through dirdata entries and add entry to reply
         reply.ok();
     }
 }

--- a/src/tiny/fs.rs
+++ b/src/tiny/fs.rs
@@ -7,7 +7,7 @@ use std::{
 use super::{
     bitmap::Bitmap,
     constants::{Disk, InodeKind},
-    directory::DirData,
+    directory::{DirData, DirEntry},
     inode::Inode,
 };
 
@@ -22,6 +22,14 @@ impl Filesystem for TinyFS {
 
         let mut inode = Inode::new();
         let mut inode_data = DirData::default();
+        inode_data.insert(
+            "a",
+            DirEntry {
+                name: "a".to_string(),
+                ino: 1,
+                kind: InodeKind::Dir,
+            },
+        );
 
         let data_buf = Vec::new();
         let mut write_buf = BufWriter::new(data_buf);

--- a/src/tiny/fs.rs
+++ b/src/tiny/fs.rs
@@ -22,14 +22,6 @@ impl Filesystem for TinyFS {
 
         let mut inode = Inode::new();
         let mut inode_data = DirData::default();
-        inode_data.insert(
-            "a",
-            DirEntry {
-                name: "a".to_string(),
-                ino: 1,
-                kind: InodeKind::Dir,
-            },
-        );
 
         let data_buf = Vec::new();
         let mut write_buf = BufWriter::new(data_buf);

--- a/src/tiny/fs.rs
+++ b/src/tiny/fs.rs
@@ -2,7 +2,6 @@ use fuse::Filesystem;
 use std::{
     ffi::c_int,
     io::{BufWriter, Write},
-    time::SystemTime,
 };
 
 use super::{
@@ -10,7 +9,6 @@ use super::{
     constants::{Disk, DIR},
     directory::DirData,
     inode::Inode,
-    type_extensions::TinyTimespec,
 };
 
 impl Filesystem for TinyFS {
@@ -22,7 +20,7 @@ impl Filesystem for TinyFS {
             return Ok(());
         }
 
-        let mut inode = Inode::default();
+        let mut inode = Inode::new();
         let mut inode_data = DirData::default();
 
         let data_buf = Vec::new();

--- a/src/tiny/fs_extensions.rs
+++ b/src/tiny/fs_extensions.rs
@@ -33,7 +33,6 @@ impl TinyFS {
             let block_location = DATA_BLOCK_BASE + (index * BLOCK_SIZE) as u64;
             let _ = write_buf.seek(SeekFrom::Start(block_location));
             let _ = write_buf.write_all(&chunk);
-
             block_ptrs[last_allocated] = block_location;
             last_allocated += 1;
         }
@@ -46,7 +45,7 @@ impl TinyFS {
     }
 
     pub fn get_dir_data(&mut self, inode: Inode) -> DirData {
-        let mut buf = vec![0u8];
+        let mut buf = vec![];
 
         for ptr in inode.block_pointers {
             if ptr == 0 {
@@ -57,8 +56,7 @@ impl TinyFS {
             buf.append(&mut block.to_vec());
         }
 
-        let s = &buf.as_slice()[1..inode.size + 1];
-
+        let s = &buf[..inode.size + 1];
         DirData::deserialize_from(s).expect("error getting dir data")
     }
 

--- a/src/tiny/fs_extensions.rs
+++ b/src/tiny/fs_extensions.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::{BufWriter, Cursor, Read, Seek, SeekFrom, Write},
+    io::{BufReader, BufWriter, Cursor, Read, Seek, SeekFrom, Write},
     time::SystemTime,
 };
 
@@ -7,7 +7,9 @@ use time::Timespec;
 
 use super::{
     bitmap::Bitmap,
-    constants::{BLOCK_SIZE, DATA_BLOCK_BASE},
+    constants::{Block, BLOCK_SIZE, DATA_BLOCK_BASE},
+    directory::DirData,
+    inode::Inode,
     type_extensions::TinyTimespec,
     TinyFS,
 };
@@ -41,5 +43,32 @@ impl TinyFS {
 
     pub fn ttl(&mut self) -> Timespec {
         SystemTime::now().to_timespec()
+    }
+
+    pub fn get_dir_data(&mut self, inode: Inode) -> DirData {
+        let mut buf = vec![0u8];
+
+        for ptr in inode.block_pointers {
+            if ptr == 0 {
+                continue;
+            }
+
+            let block = self.load_block(ptr);
+            buf.append(&mut block.to_vec());
+        }
+
+        let s = &buf.as_slice()[1..inode.size + 1];
+
+        DirData::deserialize_from(s).expect("error getting dir data")
+    }
+
+    fn load_block(&mut self, location: u64) -> Block {
+        let mut block = [0; BLOCK_SIZE];
+
+        let mut disk_buf = BufReader::new(&self.disk);
+        let _ = disk_buf.seek(SeekFrom::Start(location));
+        self.disk.read_exact(&mut block).expect("error reading block");
+
+        block
     }
 }

--- a/src/tiny/inode.rs
+++ b/src/tiny/inode.rs
@@ -87,7 +87,7 @@ impl Inode {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 #[repr(C)]
 pub struct Inode {
     pub id: u64,

--- a/src/tiny/inode.rs
+++ b/src/tiny/inode.rs
@@ -21,6 +21,7 @@ impl Inode {
             id: 0,
             kind: 0,
             block_count: 0,
+            size: 0,
             accessed_at: now.as_millis() as u64,
             modified_at: now.as_millis() as u64,
             created_at: now.as_millis() as u64,
@@ -92,6 +93,7 @@ impl Inode {
 pub struct Inode {
     pub id: u64,
     pub kind: u8,
+    pub size: usize,
     pub block_count: u64,
     pub accessed_at: u64,
     pub modified_at: u64,

--- a/src/tiny/inode.rs
+++ b/src/tiny/inode.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use super::{
-    constants::{Disk, BLOCK_SIZE, INODE_BLOCK_BASE},
+    constants::{Disk, InodeKind, BLOCK_SIZE, INODE_BLOCK_BASE},
     type_extensions::TinyTimespec,
 };
 use fuse::{FileAttr, FileType};
@@ -19,7 +19,7 @@ impl Inode {
 
         Inode {
             id: 0,
-            kind: 0,
+            kind: InodeKind::File,
             block_count: 0,
             size: 0,
             accessed_at: now.as_millis() as u64,
@@ -52,7 +52,7 @@ impl Inode {
 
     pub fn to_file_attr(&mut self) -> FileAttr {
         let mut kind = FileType::RegularFile;
-        if self.kind == 1 {
+        if self.kind == InodeKind::Dir {
             kind = FileType::Directory;
         }
 
@@ -92,7 +92,7 @@ impl Inode {
 #[repr(C)]
 pub struct Inode {
     pub id: u64,
-    pub kind: u8,
+    pub kind: InodeKind,
     pub size: usize,
     pub block_count: u64,
     pub accessed_at: u64,


### PR DESCRIPTION
## Overview

Adds support for ls

## Notes

I put the cart before the horse on this PR by implementing `ls` before writing the design doc. 

## Testing Instructions

1. Run `make run`
2. Run `ls /tmp/tiny/`
3. Observe that the are no errors. The command won't list anything because the root directory has no children atm.